### PR TITLE
Refactor some process handling 

### DIFF
--- a/StackoverflowChatbot.Tests/EventDataTests.cs
+++ b/StackoverflowChatbot.Tests/EventDataTests.cs
@@ -24,7 +24,7 @@ namespace StackoverflowChatbot.Tests
 			};
 
 		// Message is "S, say hello"
-		private static readonly JToken serializedData = JToken.Parse(System.IO.File.ReadAllText("EventData.json"));
+		private static readonly JToken _serializedData = JToken.Parse(System.IO.File.ReadAllText("EventData.json"));
 
 		public static IEnumerable<TestCase> CommandsToTestAgainst()
 		{
@@ -46,7 +46,7 @@ namespace StackoverflowChatbot.Tests
 
 		private static EventData GetDataWithCommand(string command)
 		{
-			var newData = serializedData.DeepClone();
+			var newData = _serializedData.DeepClone();
 			newData["content"] = command;
 			return EventData.FromJson(newData);
 		}

--- a/StackoverflowChatbot.Tests/PriorityProcessorTests.cs
+++ b/StackoverflowChatbot.Tests/PriorityProcessorTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using StackoverflowChatbot.Actions;
+using StackoverflowChatbot.CommandProcessors;
+using StackoverflowChatbot.NativeCommands;
+using StackoverflowChatbot.Services;
+
+namespace StackoverflowChatbot.Tests
+{
+	[ExcludeFromCodeCoverage]
+	[TestFixture]
+	public class PriorityProcessorTests
+	{
+		private PriorityProcessor _priorityProcessor = null!;
+		private CommandFactory _commandFactory = null!;
+		private EventData EventDataFromContent(string content) =>
+			EventData.FromJson(JToken.Parse(
+@"{
+	""event_type"": 1,
+	""time_stamp"": 1603377031,
+	""content"": """ + content + @""",
+	""id"": 105394918,
+	""user_id"": 4364057,
+	""user_name"": ""Squirrelkiller"",
+	""room_id"": 1,
+	""room_name"": ""Sandbox"",
+	""message_id"": 50752263
+}"));
+
+		[OneTimeSetUp]
+		public static void SetupTestClass() =>
+			Config.Manager.Config().Triggers = new List<string>()
+			{
+				"Botler! ",
+				"Botler, ",
+				"👏👏 "
+			};
+
+		[SetUp]
+		public void Setup()
+		{
+			var roomServiceMock = new Mock<IRoomService>();
+			roomServiceMock.Setup(x => x.JoinRoom(7)).Returns(true);
+			var commandStoreMock = new Mock<ICommandStore>();
+			var httpServiceMock = new Mock<IHttpService>();
+			var coll = new ServiceCollection();
+			coll.AddSingleton<ICommandStore, ICommandStore>(x => commandStoreMock.Object);
+			coll.AddSingleton<IRoomService, IRoomService>(x => roomServiceMock.Object);
+			coll.AddSingleton<IHttpService, IHttpService>(x => httpServiceMock.Object);
+			_commandFactory = new CommandFactory(coll);
+
+			coll.Should().HaveCount(3);
+			_priorityProcessor = new PriorityProcessor(commandStoreMock.Object, httpServiceMock.Object,
+				_commandFactory);
+		}
+
+		[Test]
+		public void Help_ShouldNotThrow()
+		{
+			var eventData = EventDataFromContent("Botler, help leave");
+			_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+			action.Should().BeOfType<SendMessage>();
+		}
+
+		[Test]
+		public void Unknown_ShouldBeNull()
+		{
+			var eventData = EventDataFromContent("Botler, unknown leave"); 
+			_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+			action.Should().BeNull();
+		}
+
+		[Test]
+		public void Leave_ShouldNotBeNull()
+		{
+			var eventData = EventDataFromContent("Botler, leave 11"); 
+			_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+			action.Should().NotBeNull();
+		}
+
+		[Test]
+		public void ParameterlessLeave_ShouldNotBeNull()
+		{
+			var eventData = EventDataFromContent("Botler, leave"); 
+			_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+			action.Should().NotBeNull();
+		}
+
+		[Test]
+		public void TooManyParameterLeave_ShouldNotBeNull()
+		{
+			var eventData = EventDataFromContent("Botler, leave 12 12 4234"); 
+			_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+			action.Should().NotBeNull();
+		}
+
+		[Test]
+		public void Gibberish_ShouldBeNull()
+		{
+			var eventData = EventDataFromContent("Botler, leave gibberish"); 
+			_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+			action.Should().NotBeNull();
+		}
+
+		[Test]
+		public void Join_ShouldAskForMoreRequest()
+		{
+			var eventData = EventDataFromContent("Botler, join 3"); 
+			_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+			action.Should().NotBeNull();
+		}
+
+		[Test]
+		public void AuthoredCommand_ShouldAcceptValidAdmin()
+		{
+			if (!Config.Manager.Config().Controllers.Contains(4364057))
+			{
+				Config.Manager.Config().Controllers.Add(4364057);
+			}
+			// check out in the json the user id is 4364057.
+			var eventData = EventDataFromContent("Botler, shutdown");
+			_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+			// coverage went on the I'll be back branch
+			action.Should().NotBeNull();
+		}
+
+		[Test]
+		public void AuthoredCommand_ShouldNotAcceptHacker()
+		{
+			if (Config.Manager.Config().Controllers.Contains(4364057))
+			{
+				Config.Manager.Config().Controllers.Remove(4364057);
+			}
+			var eventData = EventDataFromContent("Botler, shutdown");
+			_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+			// coverage went on YOU'RE NOT MY MOM/DAD branch.
+			action.Should().NotBeNull();
+		}
+
+		[Test]
+		public void OverLearnNativeCommand_ShouldNotOverwriteFunction()
+		{
+			var eventData = EventDataFromContent("Botler, learn join asdf");
+			_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+			action.Should().NotBeNull();
+			eventData = EventDataFromContent("Botler, join 3");
+			_priorityProcessor.ProcessNativeCommand(eventData, out action);
+			// coverage went join room (native) command
+			action.Should().NotBeNull();
+		}
+
+		[Test]
+		public void GetAllHelp_ShouldNotThrow()
+		{
+			var implementers = AppDomain.CurrentDomain.GetAssemblies().SelectMany(assembly =>
+				assembly.GetTypes().Where(x => typeof(BaseCommand).IsAssignableFrom(x) && !x.IsAbstract));
+			foreach (var implementer in implementers)
+			{
+				string? commandName = null;
+				foreach (var methodInfo in implementer.GetRuntimeMethods())
+				{
+					if (methodInfo.Name != "CommandName")
+						continue;
+
+					var nativeCommand = _commandFactory.Create(implementer, _priorityProcessor);
+					var ret = methodInfo.Invoke(nativeCommand, new object[0]);
+					commandName = ret?.ToString();
+					break;
+				}
+				var eventData = EventDataFromContent($"Botler, help {commandName}");
+				_priorityProcessor.ProcessNativeCommand(eventData, out var action);
+				action.Should().NotBeNull();
+			}
+		}
+	}
+}

--- a/StackoverflowChatbot.Tests/StackoverflowChatbot.Tests.csproj
+++ b/StackoverflowChatbot.Tests/StackoverflowChatbot.Tests.csproj
@@ -9,8 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove=".runsettings.xml.un~" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">

--- a/StackoverflowChatbot/CommandProcessors/CommandFactory.cs
+++ b/StackoverflowChatbot/CommandProcessors/CommandFactory.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using StackoverflowChatbot.NativeCommands;
+
+namespace StackoverflowChatbot.CommandProcessors
+{
+	internal class CommandFactory: ICommandFactory
+	{
+		private readonly IServiceCollection _serviceCollection;
+
+		public CommandFactory(IServiceCollection serviceCollection) => _serviceCollection = serviceCollection;
+
+		public BaseCommand Create(Type commandType, ICommandProcessor priorityProcessor)
+		{
+			if (_serviceCollection.All(x => x.ServiceType != commandType))
+			{
+				_serviceCollection.AddSingleton(commandType, commandType);
+			}
+
+			var commandProcessorDescription = _serviceCollection.FirstOrDefault(x => x.ServiceType.Name == "ICommandProcessor");
+			_serviceCollection.Remove(commandProcessorDescription);
+			_serviceCollection.AddSingleton(x => priorityProcessor);
+			var commandFactoryDescription = _serviceCollection.FirstOrDefault(x => x.ServiceType.Name == "ICommandFactory");
+			_serviceCollection.Remove(commandFactoryDescription);
+			_serviceCollection.AddSingleton<ICommandFactory>(x => this);
+			var serviceLocator = _serviceCollection.BuildServiceProvider();
+			return (BaseCommand) serviceLocator.GetService(commandType);
+		}
+	}
+}

--- a/StackoverflowChatbot/CommandProcessors/ICommandFactory.cs
+++ b/StackoverflowChatbot/CommandProcessors/ICommandFactory.cs
@@ -1,0 +1,10 @@
+using System;
+using StackoverflowChatbot.NativeCommands;
+
+namespace StackoverflowChatbot.CommandProcessors
+{
+	internal interface ICommandFactory
+	{
+		BaseCommand Create(Type commandType, ICommandProcessor priorityProcessor);
+	}
+}

--- a/StackoverflowChatbot/CommandProcessors/ICommandProcessor.cs
+++ b/StackoverflowChatbot/CommandProcessors/ICommandProcessor.cs
@@ -13,9 +13,9 @@ namespace StackoverflowChatbot.CommandProcessors
 		/// <param name="data">The command.</param>
 		/// <param name="action">Executable action on success, otherwise null.</param>
 		/// <returns>Whether or not this processor could process the command.</returns>
-		bool ProcessCommand(EventData data, out IAction? action);
+		bool ProcessNativeCommand(EventData data, out IAction? action);
 
-		Task<IAction?> ProcessCommandAsync(EventData data);
+		Task<IAction?> ProcessDynamicCommandAsync(EventData data);
 
 		bool TryGetNativeCommands(string key, out Type? value);
 

--- a/StackoverflowChatbot/CommandProcessors/PriorityProcessor.cs
+++ b/StackoverflowChatbot/CommandProcessors/PriorityProcessor.cs
@@ -75,7 +75,7 @@ namespace StackoverflowChatbot.CommandProcessors
 				return action != null;
 			}
 
-			// Why is action getting assigned but not unused?
+			// Why is action getting assigned but is unused?
 			action = null;
 			return false;
 		}

--- a/StackoverflowChatbot/CommandProcessors/PriorityProcessor.cs
+++ b/StackoverflowChatbot/CommandProcessors/PriorityProcessor.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -19,31 +18,28 @@ namespace StackoverflowChatbot.CommandProcessors
 	/// </summary>
 	internal class PriorityProcessor: ICommandProcessor
 	{
-		private const int NumberOfRequiredSummons = 3;
+		private readonly TimeSpan _dynamicCommandTimeout = TimeSpan.FromSeconds(10);
 
-		private readonly IRoomService _roomService;
 		private readonly ICommandStore _commandStore;
 		private readonly IHttpService _httpService;
-		private readonly int _roomId;
+		private readonly ICommandFactory _commandFactory;
+
 		private readonly IReadOnlyDictionary<string, Type> _nativeCommands;
-		// Key: Room; Value: Set of users who summoned to this room;
-		private readonly Dictionary<int, HashSet<int>> _peopleWhoSummoned = new Dictionary<int, HashSet<int>>();
 
 		public PriorityProcessor(
-			IRoomService roomService,
 			ICommandStore commandService,
 			IHttpService httpService,
-			int roomId)
+			ICommandFactory commandFactory)
 		{
-			_roomService = roomService;
 			_commandStore = commandService;
 			_httpService = httpService;
-			_roomId = roomId;
-			_nativeCommands = LoadNativeCommands().ToDictionary(kvp => kvp.commandName, kvp => kvp.implementer);
+			_commandFactory = commandFactory;
+			_nativeCommands = LoadNativeCommands();
 		}
 
-		private IEnumerable<(string commandName, Type implementer)> LoadNativeCommands()
+		private Dictionary<string, Type> LoadNativeCommands()
 		{
+			var commandNameImplementerTypeMapping = new Dictionary<string, Type>();
 			var implementers = AppDomain.CurrentDomain.GetAssemblies().SelectMany(assembly =>
 				assembly.GetTypes().Where(x => typeof(BaseCommand).IsAssignableFrom(x) && !x.IsAbstract));
 
@@ -54,56 +50,22 @@ namespace StackoverflowChatbot.CommandProcessors
 				{
 					Console.WriteLine(
 						$"Loaded command {instance.CommandName()} from type {implementer.Name} from {implementer.Assembly.FullName}");
-					yield return (instance.CommandName().ToLower(), implementer);
+					commandNameImplementerTypeMapping[instance.CommandName().ToLower()] = implementer;
 				}
 				else
 				{
 					Console.WriteLine($"Could not load command {implementer.FullName}.");
 				}
 			}
+
+			return commandNameImplementerTypeMapping;
 		}
 
 		/// <summary>
 		/// Process the event if a suitable command is found.
 		/// </summary>
 		/// <returns>Whether or not the event was processed.</returns>
-		public bool ProcessCommand(EventData data, out IAction? action)
-		{
-			var command = data.Command;
-
-			if (TryGetNativeCommand(data, out action))
-			{
-				return true;
-			}
-
-			if (IsCommand(command, "leave", out var commandParameter))
-			{
-				action = LeaveRoomCommand(commandParameter);
-				return true;
-			}
-
-			if (IsCommand(command, "join", out _))
-			{
-				action = JoinRoomCommand(data);
-				return true;
-			}
-
-			if (IsCommand(command, "learn", out commandParameter))
-			{
-				action = LearnCommand(commandParameter);
-				return true;
-			}	
-
-			// Why is action getting assigned but not unused?
-			action = null;
-			return false;
-		}
-
-		public bool TryGetNativeCommands(string key, out Type? value) => _nativeCommands.TryGetValue(key, out value);
-		public IEnumerable<string> NativeKeys => _nativeCommands.Keys;
-
-		//NativeKeys, 
-		private bool TryGetNativeCommand(EventData data, out IAction? action)
+		public bool ProcessNativeCommand(EventData data, out IAction? action)
 		{
 			if (_nativeCommands.TryGetValue(data.CommandName, out var commandType))
 			{
@@ -113,131 +75,21 @@ namespace StackoverflowChatbot.CommandProcessors
 				return action != null;
 			}
 
+			// Why is action getting assigned but not unused?
 			action = null;
 			return false;
 		}
 
-		private BaseCommand CreateCommandInstance(Type commandType)
-		{
-			var parameterTypes = commandType
-				.GetConstructors()
-				.First()
-				.GetParameters()
-				.Select(e => e.ParameterType);
+		public bool TryGetNativeCommands(string key, out Type? value) => _nativeCommands.TryGetValue(key, out value);
+		public IEnumerable<string> NativeKeys => _nativeCommands.Keys;
 
-			var parameterValues = new List<object>();
-			foreach(var param in parameterTypes)
-			{
-				if (param == typeof(ICommandStore))
-					parameterValues.Add(_commandStore);
-				else if (param == typeof(ICommandProcessor))
-					parameterValues.Add(this);
-			}
-
-			if (parameterValues.Any())
-				return (BaseCommand)Activator.CreateInstance(commandType, parameterValues.ToArray())!;
-
-			return (BaseCommand)Activator.CreateInstance(commandType)!;
-		}
-
-		private static bool IsCommand(string commandMessage, string commandKeyword, out string commandParameter)
-		{
-			var match = Regex.Match(commandMessage, $"^{commandKeyword} (.+)");
-
-			if (match.Success)
-			{
-				commandParameter = match.Groups[1].Value;
-				return true;
-			}
-
-			commandParameter = string.Empty;
-			return false;
-		}
-
-		private IAction LeaveRoomCommand(string commandParameter)
-		{
-			// Can be told to leave other rooms.
-			_roomService.LeaveRoom(IsSingleNumber(commandParameter.Trim(), out var room) ? room : _roomId);
-			return NewMessageAction(room > 0 ? $"Leaving room {room}!" : "Bye!");
-		}
-
-		// TODO wrap to Task
-		private IAction LearnCommand(string commandParameter)
-		{
-			var @params = commandParameter.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
-			if (@params.Length < 2)
-			{
-				return NewMessageAction("Missing args");
-			}
-
-			var name = @params[0];
-			var args = @params[1];
-			var command = new CustomCommand(name, args);
-			if (DynamicCommand.TryParse(args, out var dynamicCommand))
-			{
-				command.IsDynamic = true;
-				command.ExpectedDynamicCommandArgs = dynamicCommand!.ExpectedArgsCount;
-			}
-
-			_ = _commandStore.AddCommand(command)
-				.ContinueWith(async t =>
-				{
-					if (t.IsFaulted)
-					{
-						Exception? exception = t.Exception;
-						while (exception is AggregateException aggregateException)
-							exception = aggregateException.InnerException;
-						Console.Write(exception);
-					}
-				});
-			return NewMessageAction($"Learned the command {name}");
-		}
-
-		private SendMessage JoinRoomCommand(EventData data)
-		{
-			if (!int.TryParse(data.Command.Replace("join ", ""), out var room))
-			{
-				return NewMessageAction("Couldn't find a valid room number.");
-			}
-
-			if (!_peopleWhoSummoned.ContainsKey(room))
-			{
-				_peopleWhoSummoned.Add(room, new HashSet<int>());
-			}
-
-			if (data.SentByController())
-			{
-				var joinedByAdmin = _roomService.JoinRoom(room);
-				return NewMessageAction(joinedByAdmin ? $"I joined room {room}, Boss." : $"Couldn't join room {room}, guess I'm already there!");
-			}
-
-			if (_peopleWhoSummoned[room].Count < NumberOfRequiredSummons)
-			{
-				_ = _peopleWhoSummoned[room].Add(data.UserId);
-				return NewMessageAction($"{NumberOfRequiredSummons - _peopleWhoSummoned[room].Count} more and I'll join room {room}");
-			}
-
-			var joined = _roomService.JoinRoom(room);
-			return NewMessageAction(joined ? $"I joined room {room}." : $"Couldn't join room {room}, guess I'm already there!");
-		}
+		private BaseCommand CreateCommandInstance(Type commandType) => _commandFactory.Create(commandType, this);
 
 		private static SendMessage NewMessageAction(string message) => new SendMessage(message);
 
-		private static bool IsSingleNumber(string v, out int room)
-		{
-			if (int.TryParse(v, out var number))
-			{
-				room = number;
-				return true;
-			}
-
-			room = -1;
-			return false;
-		}
-
 		private Task<HashSet<CustomCommand>> GetCustomCommands() => _commandStore.GetCommands();
 
-		public async Task<IAction?> ProcessCommandAsync(EventData data)
+		public async Task<IAction?> ProcessDynamicCommandAsync(EventData data)
 		{
 			var commandList = await GetCustomCommands();
 			var command = commandList.FirstOrDefault(e => e.Name == data.CommandName);
@@ -267,7 +119,6 @@ namespace StackoverflowChatbot.CommandProcessors
 			if (args.Length != expectedLength)
 				return NewMessageAction($"Expected {expectedLength} args, found {args.Length} for command '{command.Name}'");
 
-			var timeout = TimeSpan.FromSeconds(10);
 			try
 			{
 				var api = Uri.UnescapeDataString(dynaCmd!.ApiAddress.AbsoluteUri);
@@ -280,7 +131,7 @@ namespace StackoverflowChatbot.CommandProcessors
 					api = string.IsNullOrEmpty(alias) ? api : $"[{alias}]({api})";
 					return NewMessageAction(api);
 				}
-				var cts = new CancellationTokenSource(timeout);
+				var cts = new CancellationTokenSource(_dynamicCommandTimeout);
 				var apiResponse = await Fetch(api, dynaCmd.Method, dynaCmd.ContentType, cts.Token);
 				var stringContent = apiResponse.ToString() ?? "{}";
 				if (string.IsNullOrEmpty(dynaCmd.JsonPath))
@@ -291,7 +142,7 @@ namespace StackoverflowChatbot.CommandProcessors
 			}
 			catch (OperationCanceledException)
 			{
-				return NewMessageAction($"I can't wait for longer than {timeout:s} and the API is slow.");
+				return NewMessageAction($"I can't wait for longer than {_dynamicCommandTimeout:s} and the API is slow.");
 			}
 		}
 

--- a/StackoverflowChatbot/Config/Manager.cs
+++ b/StackoverflowChatbot/Config/Manager.cs
@@ -8,13 +8,13 @@ namespace StackoverflowChatbot.Config
 {
 	internal static class Manager
 	{
-		private static Base? instance;
+		private static Base? _instance;
 
 		internal static string CONFIG_FILENAME = "config.json";
 
 		public static Base Config()
 		{
-			if (instance == null)
+			if (_instance == null)
 			{
 				try
 				{
@@ -30,21 +30,21 @@ namespace StackoverflowChatbot.Config
 					{
 						configData.StackToDiscordMap.Add(pair.Value, pair.Key);
 					}
-					instance = configData;
-					Console.WriteLine($"Loaded config. my triggers are: {string.Join(", ", instance.Triggers)}");
+					_instance = configData;
+					Console.WriteLine($"Loaded config. my triggers are: {string.Join(", ", _instance.Triggers)}");
 				}
 				catch (Exception e)
 				{
 					Console.WriteLine(e.ToString());
-					instance = new Base();
+					_instance = new Base();
 				}
 			}
-			return instance;
+			return _instance;
 		}
 
 		public static void SaveConfig()
 		{
-			var json = JsonSerializer.Serialize(instance);
+			var json = JsonSerializer.Serialize(_instance);
 			using var confStream = File.OpenWrite(CONFIG_FILENAME);
 			confStream.Position = 0; //Just to make sure
 			var bytes = Encoding.UTF8.GetBytes(json);

--- a/StackoverflowChatbot/NativeCommands/BaseCommand.cs
+++ b/StackoverflowChatbot/NativeCommands/BaseCommand.cs
@@ -40,7 +40,6 @@ namespace StackoverflowChatbot.NativeCommands
 		/// <summary>
 		/// If this command is only usable (and visible to) controllers. Although obviously if a help is run by a controller then everyone will see it. But if they're not a controller then they can't do it.
 		/// </summary>
-		[UsedImplicitly]
 		internal virtual bool NeedsAdmin() => false;
 
 	}

--- a/StackoverflowChatbot/NativeCommands/DynamicCommand.cs
+++ b/StackoverflowChatbot/NativeCommands/DynamicCommand.cs
@@ -50,7 +50,7 @@ namespace StackoverflowChatbot.NativeCommands
 					cmd = null;
 					return false;
 				}
-				var argsCount = Regex.Matches(api, "(={\\d+})").Count;
+				var argsCount = Regex.Matches(api, "({\\d+})").Count;
 				var options = ParseOptions(components.Last());
 				cmd = result ? new DynamicCommand(uri!, argsCount, options) : null;
 				return result;

--- a/StackoverflowChatbot/NativeCommands/Join.cs
+++ b/StackoverflowChatbot/NativeCommands/Join.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using JetBrains.Annotations;
+using StackoverflowChatbot.Actions;
+using StackoverflowChatbot.Services;
+
+namespace StackoverflowChatbot.NativeCommands
+{
+	[UsedImplicitly]
+	internal class Join: BaseCommand
+	{
+		private readonly IRoomService _roomService;
+		// Key: Room; Value: Set of users who summoned to this room;
+		private readonly Dictionary<int, HashSet<int>> _peopleWhoSummoned = new Dictionary<int, HashSet<int>>();
+		private const int NumberOfRequiredSummons = 3;
+
+		public Join(IRoomService roomService) => _roomService = roomService;
+
+		internal override IAction ProcessMessageInternal(EventData data, string[]? parameters)
+		{
+			if (parameters == null || !int.TryParse(parameters[0], out var room) || parameters.Length < 1 || parameters.Length > 1)
+			{
+				return new SendMessage("Couldn't find a valid room number.");
+			}
+
+			if (!_peopleWhoSummoned.ContainsKey(room))
+			{
+				_peopleWhoSummoned.Add(room, new HashSet<int>());
+			}
+
+			if (data.SentByController())
+			{
+				var joinedByAdmin = _roomService.JoinRoom(room);
+				return new SendMessage(joinedByAdmin ? $"I joined room {room}, Boss." : $"Couldn't join room {room}, guess I'm already there!");
+			}
+
+			if (_peopleWhoSummoned[room].Count < NumberOfRequiredSummons)
+			{
+				_ = _peopleWhoSummoned[room].Add(data.UserId);
+				return new SendMessage($"{NumberOfRequiredSummons - _peopleWhoSummoned[room].Count} more and I'll join room {room}");
+			}
+
+			var joined = _roomService.JoinRoom(room);
+			return new SendMessage(joined ? $"I joined room {room}." : $"Couldn't join room {room}, guess I'm already there!");
+		}
+
+		internal override string CommandName() => "join";
+
+		internal override string CommandDescription() => $"{NumberOfRequiredSummons} summons and I'll join room";
+	}
+}

--- a/StackoverflowChatbot/NativeCommands/Learn.cs
+++ b/StackoverflowChatbot/NativeCommands/Learn.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using StackoverflowChatbot.Actions;
+using StackoverflowChatbot.Services;
+
+namespace StackoverflowChatbot.NativeCommands
+{
+	internal class Learn: BaseCommand
+	{
+		private readonly ICommandStore _commandStore;
+
+		public Learn(ICommandStore commandStore) => _commandStore = commandStore;
+
+		internal override IAction ProcessMessageInternal(EventData eventContext, string[]? parameters)
+		{
+			if (parameters.Length < 2)
+			{
+				return new SendMessage("Missing args");
+			}
+
+			var name = parameters[0];
+			var args = parameters[1];
+			var command = new CustomCommand(name, args);
+			if (DynamicCommand.TryParse(args, out var dynamicCommand))
+			{
+				command.IsDynamic = true;
+				command.ExpectedDynamicCommandArgs = dynamicCommand!.ExpectedArgsCount;
+			}
+
+			_ = _commandStore.AddCommand(command)
+				.ContinueWith(async t =>
+				{
+					if (t.IsFaulted)
+					{
+						Exception? exception = t.Exception;
+						while (exception is AggregateException aggregateException)
+							exception = aggregateException.InnerException;
+						Console.Write(exception);
+					}
+				});
+			return new SendMessage($"Learned the command {name}");
+		}
+
+		internal override string CommandName() => "learn";
+
+		internal override string CommandDescription() => "Learns ";
+	}
+}

--- a/StackoverflowChatbot/NativeCommands/Learn.cs
+++ b/StackoverflowChatbot/NativeCommands/Learn.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using JetBrains.Annotations;
 using StackoverflowChatbot.Actions;
 using StackoverflowChatbot.Services;
 
 namespace StackoverflowChatbot.NativeCommands
 {
+	[UsedImplicitly]
 	internal class Learn: BaseCommand
 	{
 		private readonly ICommandStore _commandStore;
@@ -14,7 +16,7 @@ namespace StackoverflowChatbot.NativeCommands
 
 		internal override IAction ProcessMessageInternal(EventData eventContext, string[]? parameters)
 		{
-			if (parameters.Length < 2)
+			if (parameters == null || parameters.Length < 2)
 			{
 				return new SendMessage("Missing args");
 			}
@@ -29,15 +31,14 @@ namespace StackoverflowChatbot.NativeCommands
 			}
 
 			_ = _commandStore.AddCommand(command)
-				.ContinueWith(async t =>
+				.ContinueWith(t =>
 				{
-					if (t.IsFaulted)
-					{
-						Exception? exception = t.Exception;
-						while (exception is AggregateException aggregateException)
-							exception = aggregateException.InnerException;
-						Console.Write(exception);
-					}
+					if (!t.IsFaulted)
+						return;
+					Exception? exception = t.Exception;
+					while (exception is AggregateException aggregateException)
+						exception = aggregateException.InnerException;
+					Console.Write(exception);
 				});
 			return new SendMessage($"Learned the command {name}");
 		}

--- a/StackoverflowChatbot/NativeCommands/Leave.cs
+++ b/StackoverflowChatbot/NativeCommands/Leave.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using JetBrains.Annotations;
+using StackoverflowChatbot.Actions;
+using StackoverflowChatbot.Services;
+
+namespace StackoverflowChatbot.NativeCommands
+{
+	[UsedImplicitly]
+	internal class Leave: BaseCommand
+	{
+		private readonly IRoomService _roomService;
+
+		public Leave(IRoomService roomService) => _roomService = roomService;
+
+		internal override IAction ProcessMessageInternal(EventData eventContext, string[]? parameters)
+		{
+			if (parameters != null && parameters.Length > 1)
+			{
+				return new SendMessage("Too many parameters for leave room"); 
+			}
+
+			if (parameters == null || parameters.Length == 0)
+			{
+				_roomService.LeaveRoom(-1);
+				return new SendMessage("Bye!");
+			}
+
+			if (int.TryParse(parameters[0], out var number))
+			{
+				_roomService.LeaveRoom(number);
+				return new SendMessage($"Leaving room {number}!");
+			}
+
+			return new SendMessage("The parameter must be a room number");
+		}
+
+		internal override string CommandName() => "leave";
+
+		internal override string CommandDescription() => "Leaves the specified room. If no parameter given, leaves the current room";
+	}
+}

--- a/StackoverflowChatbot/Program.cs
+++ b/StackoverflowChatbot/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using StackoverflowChatbot.CommandProcessors;
 using StackoverflowChatbot.Config;
 using StackoverflowChatbot.Services;
 using StackoverflowChatbot.Services.Repositories;
@@ -36,13 +37,16 @@ namespace StackoverflowChatbot
 			return Host.CreateDefaultBuilder(args)
 			.ConfigureServices(
 				(hostContext, services) =>
-				_ = services.AddHostedService<Worker>()
-				.AddSingleton<IIdentityProvider>(new IdentityProvider(username, password))
-				//.AddSingleton<IRepositoryService>(new FirebaseRepositoryService(config.FirebaseProjectId))
-				.AddSingleton<IRepositoryService>(new MonkeyCacheRepositoryService("so-chatbot"))
-				.AddSingleton<ICommandStore, CommandStore>()
-				.AddSingleton<IRoomService, RoomService>()
-				.AddSingleton<IHttpService, HttpService>()
+					_ = services.AddHostedService<Worker>()
+						.AddSingleton<IIdentityProvider>(new IdentityProvider(username, password))
+						//.AddSingleton<IRepositoryService>(new FirebaseRepositoryService(config.FirebaseProjectId))
+						.AddSingleton<IRepositoryService>(new MonkeyCacheRepositoryService("so-chatbot"))
+						.AddSingleton<ICommandStore, CommandStore>()
+						.AddSingleton<IRoomService, RoomService>()
+						.AddSingleton<ICommandFactory, CommandFactory>()
+						.AddSingleton<IHttpService, HttpService>()
+						// leave it last row
+						.AddSingleton<IServiceCollection, ServiceCollection>(ser => (ServiceCollection)services)
 			);
 		}
 	}

--- a/StackoverflowChatbot/StackoverflowChatbot.csproj
+++ b/StackoverflowChatbot/StackoverflowChatbot.csproj
@@ -35,6 +35,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
 	  <_Parameter1>$(AssemblyName).Tests</_Parameter1>
 	</AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+	  <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+	</AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
PriorityProcessorTests created to increase code coverage.

Fix some _<field> naming errors.

Join, Learn, Help, Leave commands moves to NativeCommands (BaseCommand descendants)

BaseCommands now built by factory.
This enables NativeCommands to use the DI framework magic with same setup as the MVC app.

Eliminate some unnecessary dependencies.
While at it, it became clear, that `ProcessCommand` is only processing native commands, and `ProcessCommandAsync` is only processing dynamic commands. Made it clear by changing the names.