### PR TITLE
Fix argument parsing.

### DIFF
--- a/StackoverflowChatbot/Helpers/CliHelper.cs
+++ b/StackoverflowChatbot/Helpers/CliHelper.cs
@@ -38,7 +38,11 @@ namespace StackoverflowChatbot.Helpers
 
 		private static (int, string) FindPair(char token, char separator, int currentIndex, string[] textArray)
 		{
-			var builder = new StringBuilder(textArray[currentIndex] + separator);
+			var prem = textArray[currentIndex];
+			if (prem.StartsWith(token) && prem.EndsWith(token))
+				return (currentIndex, prem.Replace(token.ToString(), ""));
+
+            var builder = new StringBuilder(prem + separator);
 			var i = currentIndex + 1;
 			while (i < textArray.Length)
 			{
@@ -47,7 +51,7 @@ namespace StackoverflowChatbot.Helpers
 				if (endTxt.EndsWith(token))
 					break;
 			}
-			return (i - 1, builder.ToString().Replace(token.ToString(), ""));
+			return (i - 1, builder.ToString().Replace(token.ToString(), "").Trim());
 		}
 	}
 }


### PR DESCRIPTION
Cases like `command 'test1' 'test2'` would fail on previous version. This is now handled.